### PR TITLE
Set default searchengines settings for qutebrowser

### DIFF
--- a/repo/qutebrowser/config.py
+++ b/repo/qutebrowser/config.py
@@ -6,3 +6,8 @@
 # Uncomment this to still load settings configured via autoconfig.yml
 config.load_autoconfig()
 config.bind('m', 'spawn chrome-media {url}')
+
+c.url.searchengines = {
+    "DEFAULT": "https://www.google.com/search?q={}",
+    "aw": "https://wiki.archlinux.org/?search={}"
+}


### PR DESCRIPTION
Use aw as shortcut to archwiki
Use google as default engine